### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,6 +1,6 @@
 # CryptoBallot Whitepaper - DRAFT - Work In Progress
 
-##Definitions
+## Definitions
 
  - VotersList:  Web application for managing voter information and public keys.
 
@@ -13,7 +13,7 @@
  - VotersList Administrator: A semi-trusted agent that is responsible for uploading and certifying the VotersList Document. This agent would generally be the Cheif Electoral Officer responsible for the election. 
 
 
-##VotersList
+## VotersList
 
 The CrytoBallot VotersList is a RESTful web application for managing, distributing, and tamperproofing voter identity information. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
