### PR TITLE
Update crates.io badge URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ CryptoBallot
 ============
 
 [![docs](https://docs.rs/cryptoballot/badge.svg)](https://cryptoballot.com/doc/cryptoballot/index.html)
-[![crates.io](https://meritbadge.herokuapp.com/cryptoballot)](https://crates.io/crates/cryptoballot)
+[![crates.io](https://img.shields.io/crates/v/cryptoballot.svg)](https://crates.io/crates/cryptoballot)
+[![license](https://img.shields.io/crates/l/cryptoballot.svg)](https://github.com/cryptoballot/cryptoballot/blob/master/LICENSE)
 [![checks](https://github.com/cryptoballot/cryptoballot/workflows/checks/badge.svg)](https://github.com/cryptoballot/cryptoballot/actions)
 
 


### PR DESCRIPTION
This pull request updates the crates.io badge URL in the README.md file. The previous URL was outdated and has been replaced with a new URL that points to the latest version of the crate.